### PR TITLE
feat: store body emails as compressed strings

### DIFF
--- a/config/sentemails.php
+++ b/config/sentemails.php
@@ -13,5 +13,9 @@ return [
     // emails per page
     'perPage' => 10,
 
-    'noEmailsMessage' => 'No emails found.'
+    'noEmailsMessage' => 'No emails found.',
+
+    // body emails are stored as compressed strings to save db disk
+    /* Do not change after first mail is stored */
+    'compressBody' => false,
 ];

--- a/src/Models/SentEmail.php
+++ b/src/Models/SentEmail.php
@@ -7,4 +7,17 @@ use Illuminate\Database\Eloquent\Model;
 class SentEmail extends Model
 {
     protected $guarded = [];
+
+    public function getBodyAttribute($compressed) {
+        return config('sentemails.compressBody')
+                ? gzinflate(base64_decode($compressed))
+                : $compressed;
+    }
+
+    public function setBodyAttribute($raw) {
+        $body = config('sentemails.compressBody')
+                ? base64_encode(gzdeflate($raw, 9))
+                : $raw;
+        $this->attributes['body'] = $body;
+    }
 }


### PR DESCRIPTION
This feature allows to save space in db. Use it before storing the first email