### PR TITLE
Handle email attachments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ composer.lock
 vendor
 .idea
 .phpunit.result.cache
+phpunit.xml.bak
+test-results

--- a/README.md
+++ b/README.md
@@ -64,9 +64,9 @@ You can change the views to match your theme if desired.
 
 ## Usage
 
-As soon as a email is sent it will be added to a database table and will be viewable in /admin/sentemails.
+As soon as an email is sent it will be added to a database table and will be viewable in /sentemails.
 
-> Note you have to be logged in to be able to see admin/sentemails, if you are not logged in when you attempt to see admin/sentemails you will be redirected to a login route.
+> Note you have to be logged in to be able to see /sentemails, if you are not logged in when you attempt to see /sentemails you will be redirected to a login route.
 
 ### Changelog
 

--- a/config/sentemails.php
+++ b/config/sentemails.php
@@ -5,13 +5,15 @@
  */
 return [
     //set the route path to load the sent emails ui defaults to /sentemails
-    'routepath'  => 'admin/sentemails',
+    'routepath'  => 'sentemails',
 
     // set the route middlewares to apply on the sent emails ui
-    'middleware' => ['web', 'auth'],
+    'middleware' => ['web'],
 
     // emails per page
     'perPage' => 10,
+
+    'storeAttachments' => true,
 
     'noEmailsMessage' => 'No emails found.',
 

--- a/config/sentemails.php
+++ b/config/sentemails.php
@@ -8,7 +8,7 @@ return [
     'routepath'  => 'sentemails',
 
     // set the route middlewares to apply on the sent emails ui
-    'middleware' => ['web'],
+    'middleware' => ['web', 'auth'],
 
     // emails per page
     'perPage' => 10,

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,23 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit
-  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  bootstrap="vendor/autoload.php"
-  backupGlobals="false"
-  backupStaticAttributes="false"
-  colors="true"
-  verbose="true"
-  convertErrorsToExceptions="true"
-  convertNoticesToExceptions="true"
-  convertWarningsToExceptions="true"
-  processIsolation="false"
-  stopOnFailure="false"
-  xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
->
-  <coverage>
-    <include>
-      <directory suffix=".php">src/</directory>
-    </include>
-  </coverage>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="vendor/autoload.php" backupGlobals="false" colors="true" processIsolation="false" stopOnFailure="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd" cacheDirectory=".phpunit.cache" backupStaticProperties="false">
   <testsuites>
     <testsuite name="Test">
       <directory suffix="Test.php">./tests</directory>
@@ -25,6 +7,11 @@
   </testsuites>
   <php>
     <env name="DB_CONNECTION" value="testing"/>
-<!--    <env name="APP_KEY" value="base64:2fl+Ktvkfl+Fuz4Qp/A75G2RTiWVA/ZoKZvp6fiiM10="/>-->
+    <!--    <env name="APP_KEY" value="base64:2fl+Ktvkfl+Fuz4Qp/A75G2RTiWVA/ZoKZvp6fiiM10="/>-->
   </php>
+  <source>
+    <include>
+      <directory suffix=".php">src/</directory>
+    </include>
+  </source>
 </phpunit>

--- a/src/Controllers/SentEmailsController.php
+++ b/src/Controllers/SentEmailsController.php
@@ -3,8 +3,10 @@
 namespace Dcblogdev\LaravelSentEmails\Controllers;
 
 use Citco\Carbon;
+use Dcblogdev\LaravelSentEmails\Models\SentEmailAttachment;
 use Illuminate\Contracts\View\View;
 use Dcblogdev\LaravelSentEmails\Models\SentEmail;
+use Symfony\Component\HttpFoundation\BinaryFileResponse;
 
 class SentEmailsController
 {
@@ -53,5 +55,12 @@ class SentEmailsController
         $email = SentEmail::findOrFail($id);
 
         return $email->body;
+    }
+
+    public function downloadAttachment(string $id): BinaryFileResponse
+    {
+        $attachment = SentEmailAttachment::findOrFail($id);
+
+        return response()->download(storage_path('app/'.$attachment->path), $attachment->filename);
     }
 }

--- a/src/Models/SentEmail.php
+++ b/src/Models/SentEmail.php
@@ -2,10 +2,15 @@
 
 namespace Dcblogdev\LaravelSentEmails\Models;
 
+use Dcblogdev\LaravelSentEmails\database\factories\SentEmailFactory;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 
 class SentEmail extends Model
 {
+    use HasFactory;
+
     protected $fillable = [
         'date',
         'from',
@@ -15,6 +20,11 @@ class SentEmail extends Model
         'subject',
         'body'
     ];
+
+    protected static function newFactory(): SentEmailFactory
+    {
+        return SentEmailFactory::new();
+    }
 
     public function getBodyAttribute($compressed): string
     {
@@ -29,5 +39,10 @@ class SentEmail extends Model
                 ? base64_encode(gzdeflate($raw, 9))
                 : $raw;
         $this->attributes['body'] = $body;
+    }
+
+    public function attachments(): HasMany
+    {
+        return $this->hasMany(SentEmailAttachment::class);
     }
 }

--- a/src/Models/SentEmail.php
+++ b/src/Models/SentEmail.php
@@ -45,4 +45,9 @@ class SentEmail extends Model
     {
         return $this->hasMany(SentEmailAttachment::class);
     }
+
+    public function applyFilters()
+    {
+
+    }
 }

--- a/src/Models/SentEmailAttachment.php
+++ b/src/Models/SentEmailAttachment.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Dcblogdev\LaravelSentEmails\Models;
+
+use Dcblogdev\LaravelSentEmails\database\factories\SentEmailAttachmentFactory;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class SentEmailAttachment extends Model
+{
+    use HasFactory;
+
+    protected $table = 'sent_emails_attachments';
+
+    protected $fillable = [
+        'sent_email_id',
+        'filename',
+        'path'
+    ];
+
+    protected static function newFactory(): SentEmailAttachmentFactory
+    {
+        return SentEmailAttachmentFactory::new();
+    }
+}

--- a/src/SentEmailsServiceProvider.php
+++ b/src/SentEmailsServiceProvider.php
@@ -19,6 +19,7 @@ class SentEmailsServiceProvider extends ServiceProvider
 
         $this->loadViewsFrom(__DIR__.'/resources/views', 'sentemails');
         $this->loadRoutesFrom(__DIR__ . '/routes/web.php');
+        $this->loadMigrationsFrom(__DIR__ . '/database/migrations');
 
         if ($this->app->runningInConsole()) {
 
@@ -26,16 +27,14 @@ class SentEmailsServiceProvider extends ServiceProvider
                 __DIR__.'/../config/sentemails.php' => config_path('sentemails.php'),
             ], 'config');
 
-            $timestamp = date('Y_m_d_His', time());
             $this->publishes([
-                __DIR__.'/database/migrations/create_sent_emails_table.php' => $this->app->databasePath() . "/migrations/{$timestamp}_create_sent_emails_table.php",
+                __DIR__.'/database/migrations/2020_07_16_222057_create_sent_emails_table.php' => $this->app->databasePath() . "/migrations/2020_07_16_222057_create_sent_emails_table.php",
+                __DIR__.'/database/migrations/2024_05_07_222057_create_sent_emails_attachments_table.php' => $this->app->databasePath() . "/migrations/{2024_05_07_222057_create_sent_emails_attachments_table.php",
             ], 'migrations');
 
-            // Publishing the views.
             $this->publishes([
                 __DIR__.'/resources/views' => resource_path('views/vendor/sentemails'),
             ], 'views');
-
         }
     }
 

--- a/src/database/factories/SentEmailAttachmentFactory.php
+++ b/src/database/factories/SentEmailAttachmentFactory.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Dcblogdev\LaravelSentEmails\database\factories;
+
+use Dcblogdev\LaravelSentEmails\Models\SentEmail;
+use Dcblogdev\LaravelSentEmails\Models\SentEmailAttachment;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Str;
+
+class SentEmailAttachmentFactory extends Factory
+{
+    protected $model = SentEmailAttachment::class;
+
+    public function definition(): array
+    {
+        return [
+            'sent_email_id' => SentEmail::factory(),
+            'filename' => Str::random(10) . '.txt',
+            'path' => 'sent-emails/' . Str::random(10) . '.txt'
+        ];
+    }
+}
+

--- a/src/database/factories/SentEmailFactory.php
+++ b/src/database/factories/SentEmailFactory.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Dcblogdev\LaravelSentEmails\database\factories;
+
+use Dcblogdev\LaravelSentEmails\Models\SentEmail;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class SentEmailFactory extends Factory
+{
+    protected $model = SentEmail::class;
+
+    public function definition(): array
+    {
+        return [
+            'date'        => date('Y-m-d H:i:s'),
+            'from'        => fake()->email,
+            'to'          => fake()->email,
+            'cc'          => fake()->email,
+            'bcc'         => fake()->email,
+            'subject'     => fake()->sentence,
+            'body'        => fake()->realText
+        ];
+    }
+}
+

--- a/src/database/migrations/2020_07_16_222057_create_sent_emails_table.php
+++ b/src/database/migrations/2020_07_16_222057_create_sent_emails_table.php
@@ -4,14 +4,9 @@ use Illuminate\Support\Facades\Schema;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Migrations\Migration;
 
-class CreateSentEmailsTable extends Migration
+return new class extends Migration
 {
-    /**
-     * Run the migrations.
-     *
-     * @return void
-     */
-    public function up()
+    public function up(): void
     {
         Schema::create('sent_emails', function (Blueprint $table) {
             $table->increments('id');
@@ -26,13 +21,8 @@ class CreateSentEmailsTable extends Migration
         });
     }
 
-    /**
-     * Reverse the migrations.
-     *
-     * @return void
-     */
-    public function down()
+    public function down(): void
     {
         Schema::dropIfExists('sent_emails');
     }
-}
+};

--- a/src/database/migrations/2024_05_07_222057_create_sent_emails_attachments_table.php
+++ b/src/database/migrations/2024_05_07_222057_create_sent_emails_attachments_table.php
@@ -1,0 +1,25 @@
+<?php
+
+use Dcblogdev\LaravelSentEmails\Models\SentEmail;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('sent_emails_attachments', function (Blueprint $table) {
+            $table->increments('id');
+            $table->foreignIdFor(SentEmail::class)->nullable();
+            $table->string('filename')->nullable();
+            $table->text('path')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('sent_emails_attachments');
+    }
+};

--- a/src/resources/views/email.blade.php
+++ b/src/resources/views/email.blade.php
@@ -16,6 +16,18 @@
                     {{ __('To') }}: {{ $email->to }}<br>
                     @if ($email->cc !=''){{ __('CC') }}: {{ $email->cc }}<br>@endif
                     @if ($email->bcc !=''){{ __('BCC') }}: {{ $email->bcc }}<br>@endif
+                    @if (config('sentemails.storeAttachments'))
+                        @if ($email->attachments->count() > 0)
+                            {{ __('Attachment') }}
+                        @endif
+                        @foreach($email->attachments as $attachment)
+                            <a
+                                class="bg-gray-200 px-2 py-1 rounded-lg text-xs text-gray-800 hover:text-gray-900 hover:bg-gray-300"
+                                href="{{ route('sentemails.downloadAttachment', $attachment->id) }}">
+                                    {{ $attachment->filename }}
+                            </a>
+                        @endforeach
+                    @endif
                 </span>
             </p>
             <div class="flex items-center">

--- a/src/resources/views/index.blade.php
+++ b/src/resources/views/index.blade.php
@@ -4,7 +4,7 @@
 <title>{{ __('Sent Emails') }}</title>
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
-<link href="https://unpkg.com/tailwindcss@^1.0/dist/tailwind.min.css" rel="stylesheet">
+<script src="https://cdn.tailwindcss.com"></script>
 </head>
 <body class="bg-gray-200">
 
@@ -86,6 +86,9 @@
                         <span class="text-xs text-gray-500">{{ $email->created_at->diffForHumans() }}</span>
                         </div>
                         <p class="text-sm text-gray-900">{{ $email->subject }}</p>
+                        @if(config('sentemails.storeAttachments'))
+                            {{ __('Attachments') }}: {{ $email->attachments->count() }}
+                        @endif
                     </a>
                 @endforeach
             </div>

--- a/src/routes/web.php
+++ b/src/routes/web.php
@@ -7,4 +7,5 @@ Route::middleware(config('sentemails.middleware'))->group(function () {
     Route::get(config('sentemails.routepath'), [SentEmailsController::class, 'index'])->name('sentemails.index');
     Route::get(config('sentemails.routepath').'/email/{id}', [SentEmailsController::class, 'email'])->name('sentemails.email');
     Route::get(config('sentemails.routepath').'/body/{id}', [SentEmailsController::class, 'body'])->name('sentemails.body');
+    Route::get(config('sentemails.routepath').'/attachment-{id}', [SentEmailsController::class, 'downloadAttachment'])->name('sentemails.downloadAttachment');
 });

--- a/tests/SentEmailsTest.php
+++ b/tests/SentEmailsTest.php
@@ -1,8 +1,37 @@
 <?php
 
-use Symfony\Component\Routing\Exception\RouteNotFoundException;
+use Dcblogdev\LaravelSentEmails\Models\SentEmail;
+use Dcblogdev\LaravelSentEmails\Models\SentEmailAttachment;
 
-//fails due to login route not existing directly in package
-test('guests cannot access the sent emails page', function () {
-    $this->get(route('sentemails.index'))->assertStatus(500);
+test('can see emails inbox', function () {
+    $this->get(route('sentemails.index'))->assertOk();
+});
+
+test('can see email', function () {
+    $email = SentEmail::factory()->create();
+
+    $this->get(route('sentemails.email', $email))->assertOk();
+});
+
+test('can see email body', function () {
+    $email = SentEmail::factory()->create();
+
+    $this->get(route('sentemails.body', $email))->assertOk();
+});
+
+test('can download attachment', function () {
+
+    $filename = 'testfile.pdf';
+    $path = storage_path('app/public/testfile.pdf');
+
+    file_put_contents($filename, 'Test file content.');
+
+    $attachment = SentEmailAttachment::factory()->create([
+        'filename' => $filename,
+        'path' => $path,
+    ]);
+
+    $this->get(route('sentemails.downloadAttachment', $attachment->id))->assertDownload($filename);
+
+    unlink($filename);
 });

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -3,11 +3,14 @@
 namespace Dcblogdev\LaravelSentEmails\Tests;
 
 use Dcblogdev\LaravelSentEmails\SentEmailsServiceProvider;
+use Illuminate\Foundation\Testing\LazilyRefreshDatabase;
 use Illuminate\Support\Str;
 use Orchestra\Testbench\TestCase as Orchestra;
 
 class TestCase extends Orchestra
 {
+    use LazilyRefreshDatabase;
+
     protected function getPackageProviders($app): array
     {
         return [

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -29,5 +29,8 @@ class TestCase extends Orchestra
             'database' => ':memory:',
             'prefix'   => '',
         ]);
+        $app['config']->set('sentemails.middleware', [
+            'web'
+        ]);
     }
 }


### PR DESCRIPTION
Added a new migration to create an attachments table, and an option to store attachments, on by default.

updated UI to show attachments.

![328136750-f417f30c-0062-4e90-9cea-89098ca39bf0](https://github.com/dcblogdev/laravel-sent-emails/assets/1018170/1d88fb3e-d077-48c2-b3da-1d30a00b73ae)
